### PR TITLE
Make regexp strings "raw-strings"

### DIFF
--- a/vxi11/vxi11.py
+++ b/vxi11/vxi11.py
@@ -131,7 +131,7 @@ def parse_visa_resource_string(resource_string):
     # TCPIP0::10.0.0.1::gpib,5::INSTR
     # TCPIP0::10.0.0.1::usb0::INSTR
     # TCPIP0::10.0.0.1::usb0[1234::5678::MYSERIAL::0]::INSTR
-    m = re.match('^(?P<prefix>(?P<type>TCPIP)\d*)(::(?P<arg1>[^\s:]+))'
+    m = re.match(r'^(?P<prefix>(?P<type>TCPIP)\d*)(::(?P<arg1>[^\s:]+))'
             '(::(?P<arg2>[^\s:]+(\[.+\])?))?(::(?P<suffix>INSTR))$',
             resource_string, re.I)
 


### PR DESCRIPTION
Fixes:
* SyntaxWarning: invalid escape sequence '\d'
* SyntaxWarning: invalid escape sequence '\s'